### PR TITLE
Add appUpdatePollInterval property when configuring

### DIFF
--- a/build/init.js
+++ b/build/init.js
@@ -75,6 +75,7 @@ exports.configure = function(image, uuid, options) {
   }).then(function(results) {
     var configuration;
     configuration = results.manifest.configuration;
+    results.config.appUpdatePollInterval = (options.appUpdatePollInterval || 1) * 60000;
     return utils.writeConfigJSON(image, results.config, configuration.config).then(function() {
       return operations.execute(image, configuration.operations, options);
     });

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -68,6 +68,9 @@ exports.configure = (image, uuid, options) ->
 	.then (results) ->
 		configuration = results.manifest.configuration
 
+		# Convert from seconds to milliseconds
+		results.config.appUpdatePollInterval = (options.appUpdatePollInterval or 1) * 60000
+
 		utils.writeConfigJSON(image, results.config, configuration.config).then ->
 			return operations.execute(image, configuration.operations, options)
 

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -192,6 +192,49 @@ wary.it 'should emit burn events when initializing a raspberry pi',
 		m.chai.expect(args[0].percentage).to.equal(100)
 		m.chai.expect(args[0].eta).to.equal(0)
 
+wary.it 'should accept an appUpdatePollInterval setting',
+	raspberrypi: RASPBERRYPI
+, (images) ->
+
+	options =
+		network: 'ethernet'
+		appUpdatePollInterval: 2
+
+	resin.models.device.get(UUIDS.raspberrypi).then (device) ->
+		init.configure(images.raspberrypi, UUIDS.raspberrypi, options)
+		.then(waitStream)
+		.then _.partial imagefs.read,
+			partition:
+				primary: 4
+				logical: 1
+			path: '/config.json'
+			image: images.raspberrypi
+		.then(extract)
+		.then(JSON.parse)
+		.then (config) ->
+			m.chai.expect(config.appUpdatePollInterval).to.equal(120000)
+
+wary.it 'should default appUpdatePollInterval to 1 second',
+	raspberrypi: RASPBERRYPI
+, (images) ->
+
+	options =
+		network: 'ethernet'
+
+	resin.models.device.get(UUIDS.raspberrypi).then (device) ->
+		init.configure(images.raspberrypi, UUIDS.raspberrypi, options)
+		.then(waitStream)
+		.then _.partial imagefs.read,
+			partition:
+				primary: 4
+				logical: 1
+			path: '/config.json'
+			image: images.raspberrypi
+		.then(extract)
+		.then(JSON.parse)
+		.then (config) ->
+			m.chai.expect(config.appUpdatePollInterval).to.equal(60000)
+
 ########################################################################
 # Intel Edison
 ########################################################################


### PR DESCRIPTION
This property is not handled automatically by `resin-device-config`
because the user gets a chance to configure it when provisioning a
device with the CLI.