### PR TITLE
Upgrade Resin Device Config to v2.1.0

### DIFF
--- a/build/init.js
+++ b/build/init.js
@@ -75,7 +75,9 @@ exports.configure = function(image, uuid, options) {
   }).then(function(results) {
     var configuration;
     configuration = results.manifest.configuration;
-    results.config.appUpdatePollInterval = (options.appUpdatePollInterval || 1) * 60000;
+    if (options.appUpdatePollInterval != null) {
+      results.config.appUpdatePollInterval = String(options.appUpdatePollInterval * 60000);
+    }
     return utils.writeConfigJSON(image, results.config, configuration.config).then(function() {
       return operations.execute(image, configuration.operations, options);
     });

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -69,7 +69,8 @@ exports.configure = (image, uuid, options) ->
 		configuration = results.manifest.configuration
 
 		# Convert from seconds to milliseconds
-		results.config.appUpdatePollInterval = (options.appUpdatePollInterval or 1) * 60000
+		if options.appUpdatePollInterval?
+			results.config.appUpdatePollInterval = String(options.appUpdatePollInterval * 60000)
 
 		utils.writeConfigJSON(image, results.config, configuration.config).then ->
 			return operations.execute(image, configuration.operations, options)

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "lodash": "^3.10.1",
-    "resin-device-config": "^2.0.1",
+    "resin-device-config": "^2.1.0",
     "resin-device-operations": "^1.2.4",
     "resin-image-fs": "^2.1.0",
-    "resin-sdk": "^2.7.0",
+    "resin-sdk": "^2.7.3",
     "string-to-stream": "^1.0.1"
   }
 }

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -212,7 +212,7 @@ wary.it 'should accept an appUpdatePollInterval setting',
 		.then(extract)
 		.then(JSON.parse)
 		.then (config) ->
-			m.chai.expect(config.appUpdatePollInterval).to.equal(120000)
+			m.chai.expect(config.appUpdatePollInterval).to.equal('120000')
 
 wary.it 'should default appUpdatePollInterval to 1 second',
 	raspberrypi: RASPBERRYPI
@@ -233,7 +233,7 @@ wary.it 'should default appUpdatePollInterval to 1 second',
 		.then(extract)
 		.then(JSON.parse)
 		.then (config) ->
-			m.chai.expect(config.appUpdatePollInterval).to.equal(60000)
+			m.chai.expect(config.appUpdatePollInterval).to.equal('60000')
 
 ########################################################################
 # Intel Edison


### PR DESCRIPTION
- Use `appUpdatePollInterval` default value from `resin-device-config`.