### PR TITLE
Take a device type instead of a uuid in initialize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Documentation
 
 * [init](#module_init)
   * [.configure(image, uuid, options)](#module_init.configure) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
-  * [.initialize(image, uuid, options)](#module_init.initialize) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
+  * [.initialize(image, deviceType, options)](#module_init.initialize) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
 
 <a name="module_init.configure"></a>
 ### init.configure(image, uuid, options) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
@@ -64,7 +64,7 @@ init.configure('my/rpi.img', '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7f
 		console.log('Configuration finished')
 ```
 <a name="module_init.initialize"></a>
-### init.initialize(image, uuid, options) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
+### init.initialize(image, deviceType, options) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
 **Kind**: static method of <code>[init](#module_init)</code>  
 **Summary**: Initialize an image  
 **Returns**: <code>Promise.&lt;EventEmitter&gt;</code> - initialization event emitter  
@@ -73,12 +73,12 @@ init.configure('my/rpi.img', '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7f
 | Param | Type | Description |
 | --- | --- | --- |
 | image | <code>String</code> | path to image |
-| uuid | <code>String</code> | device uuid |
+| deviceType | <code>String</code> | device type slug |
 | options | <code>Object</code> | configuration options |
 
 **Example**  
 ```js
-init.initialize('my/rpi.img', '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', network: 'ethernet').then (configuration) ->
+init.initialize('my/rpi.img', 'raspberry-pi', network: 'ethernet').then (configuration) ->
 
 	configuration.on('stdout', process.stdout.write)
 	configuration.on('stderr', process.stderr.write)

--- a/build/init.js
+++ b/build/init.js
@@ -26,9 +26,11 @@ THE SOFTWARE.
 /**
  * @module init
  */
-var Promise, deviceConfig, operations, utils;
+var Promise, deviceConfig, operations, resin, utils;
 
 Promise = require('bluebird');
+
+resin = require('resin-sdk');
 
 deviceConfig = require('resin-device-config');
 
@@ -91,13 +93,13 @@ exports.configure = function(image, uuid, options) {
  * @public
  *
  * @param {String} image - path to image
- * @param {String} uuid - device uuid
+ * @param {String} deviceType - device type slug
  * @param {Object} options - configuration options
  *
  * @returns {Promise<EventEmitter>} initialization event emitter
  *
  * @example
- * init.initialize('my/rpi.img', '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', network: 'ethernet').then (configuration) ->
+ * init.initialize('my/rpi.img', 'raspberry-pi', network: 'ethernet').then (configuration) ->
  *
  * 	configuration.on('stdout', process.stdout.write)
  * 	configuration.on('stderr', process.stderr.write)
@@ -116,8 +118,8 @@ exports.configure = function(image, uuid, options) {
  * 		console.log('Configuration finished')
  */
 
-exports.initialize = function(image, uuid, options) {
-  return utils.getManifestByDevice(uuid).then(function(manifest) {
+exports.initialize = function(image, deviceType, options) {
+  return resin.models.device.getManifestBySlug(deviceType).then(function(manifest) {
     return operations.execute(image, manifest.initialization.operations, options);
   });
 };

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -27,6 +27,7 @@ THE SOFTWARE.
 ###
 
 Promise = require('bluebird')
+resin = require('resin-sdk')
 deviceConfig = require('resin-device-config')
 operations = require('resin-device-operations')
 utils = require('./utils')
@@ -81,13 +82,13 @@ exports.configure = (image, uuid, options) ->
 # @public
 #
 # @param {String} image - path to image
-# @param {String} uuid - device uuid
+# @param {String} deviceType - device type slug
 # @param {Object} options - configuration options
 #
 # @returns {Promise<EventEmitter>} initialization event emitter
 #
 # @example
-# init.initialize('my/rpi.img', '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7fc6c4f7b465c9', network: 'ethernet').then (configuration) ->
+# init.initialize('my/rpi.img', 'raspberry-pi', network: 'ethernet').then (configuration) ->
 #
 # 	configuration.on('stdout', process.stdout.write)
 # 	configuration.on('stderr', process.stderr.write)
@@ -105,6 +106,6 @@ exports.configure = (image, uuid, options) ->
 # 	configuration.on 'end', ->
 # 		console.log('Configuration finished')
 ###
-exports.initialize = (image, uuid, options) ->
-	utils.getManifestByDevice(uuid).then (manifest) ->
+exports.initialize = (image, deviceType, options) ->
+	resin.models.device.getManifestBySlug(deviceType).then (manifest) ->
 		return operations.execute(image, manifest.initialization.operations, options)

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -141,7 +141,7 @@ wary.it 'should initialize a raspberry pi image',
 
 	init.configure(images.raspberrypi, UUIDS.raspberrypi, options)
 	.then(waitStream).then ->
-		init.initialize(images.raspberrypi, UUIDS.raspberrypi, drive: images.random)
+		init.initialize(images.raspberrypi, 'raspberry-pi', drive: images.random)
 	.then(waitStream).then ->
 		Promise.props
 			raspberrypi: fs.readFileAsync(images.raspberrypi)
@@ -161,7 +161,7 @@ wary.it 'should emit state events when initializing a raspberry pi',
 
 	init.configure(images.raspberrypi, UUIDS.raspberrypi, options)
 	.then(waitStream).then ->
-		init.initialize(images.raspberrypi, UUIDS.raspberrypi, drive: images.random)
+		init.initialize(images.raspberrypi, 'raspberry-pi', drive: images.random)
 	.then (initialization) ->
 		initialization.on('state', spy)
 		return waitStream(initialization)
@@ -182,7 +182,7 @@ wary.it 'should emit burn events when initializing a raspberry pi',
 
 	init.configure(images.raspberrypi, UUIDS.raspberrypi, options)
 	.then(waitStream).then ->
-		init.initialize(images.raspberrypi, UUIDS.raspberrypi, drive: images.random)
+		init.initialize(images.raspberrypi, 'raspberry-pi', drive: images.random)
 	.then (initialization) ->
 		initialization.on('burn', spy)
 		return waitStream(initialization)
@@ -305,7 +305,7 @@ wary.it 'should be able to initialize an intel edison with a script',
 		init.configure(images.edison, UUIDS.edison, options)
 		.then(waitStream)
 		.then ->
-			init.initialize(images.edison, UUIDS.edison, options)
+			init.initialize(images.edison, 'intel-edison', options)
 		.then (initialization) ->
 
 			initialization.on 'stdout', (data) ->


### PR DESCRIPTION
Currently `initialize()` takes a device uuid, but if we look closer,
there is no need for this. `configure()` requires a uuid since it uses
the unique device identity to generate a `config.json`, but
`initialize()`, in the other hand, just uses the uuid to retrieve it's
device type.

To simplify the interface, `initialize()` now takes a device type slug.