### PR TITLE
Upgrade SDK to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "resin-device-config": "^2.1.0",
     "resin-device-operations": "^1.2.5",
     "resin-image-fs": "^2.1.0",
-    "resin-sdk": "^2.7.3",
+    "resin-sdk": "^3.0.0",
     "string-to-stream": "^1.0.1"
   }
 }

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -20,8 +20,8 @@ prepareDevice = (deviceType) ->
 	resin.models.application.has(applicationName).then (hasApplication) ->
 		return if hasApplication
 		resin.models.application.create(applicationName, deviceType)
-	.then ->
-		uuid = resin.models.device.generateUUID()
+	.then(resin.models.device.generateUUID)
+	.then (uuid) ->
 		resin.models.device.register(applicationName, uuid)
 	.get('uuid')
 
@@ -323,6 +323,7 @@ resin.auth.login
 	username: process.env.RESIN_E2E_USERNAME
 	password: process.env.RESIN_E2E_PASSWORD
 .then ->
+	console.log('Logged in')
 	Promise.props
 		raspberrypi: prepareDevice('Raspberry Pi')
 		edison: prepareDevice('Intel Edison')


### PR DESCRIPTION
Breaking changes in this version:

- `resin.models.device.generateUUID` is now async.