### PR TITLE
Do not set `os` manually during the tests

### DIFF
--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -293,10 +293,6 @@ wary.it 'should be able to initialize an intel edison with a script',
 		network: 'wifi'
 		wifiSsid: 'mywifissid'
 		wifiKey: 'mywifikey'
-		os: os.platform()
-
-	if options.os is 'darwin'
-		options.os = 'osx'
 
 	stdout = ''
 	stderr = ''


### PR DESCRIPTION
This option is now automatically added by `resin-device-operations`.

See https://github.com/resin-io/resin-device-operations/pull/21