### PR TITLE
Upgrade Resin SDK to v5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "resin-device-config": "^3.0.0",
     "resin-device-operations": "^1.2.5",
     "resin-image-fs": "^2.1.0",
-    "resin-sdk": "^4.0.0",
+    "resin-sdk": "^5.2.0",
     "string-to-stream": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "lodash": "^3.10.1",
-    "resin-device-config": "^3.0.0",
+    "resin-device-config": "^3.0.1",
     "resin-device-operations": "^1.2.5",
     "resin-image-fs": "^2.1.0",
     "resin-sdk": "^5.2.0",


### PR DESCRIPTION
Version v5.0.0 includes support for shorter uuids.

Signed-off-by: Juan Cruz Viotti <jviottidc@gmail.com>