### PR TITLE
Attempt to read device type from first partition

### DIFF
--- a/build/init.js
+++ b/build/init.js
@@ -64,7 +64,9 @@ utils = require('./utils');
 
 exports.configure = function(image, uuid, options) {
   return Promise.props({
-    manifest: utils.getManifestByDevice(uuid),
+    manifest: resin.models.device.get(uuid).then(function(device) {
+      return utils.getManifestByDeviceType(image, device.device_type);
+    }),
     config: deviceConfig.getByDevice(uuid, options)
   }).then(function(results) {
     var configuration;
@@ -111,7 +113,7 @@ exports.configure = function(image, uuid, options) {
  */
 
 exports.initialize = function(image, deviceType, options) {
-  return resin.models.device.getManifestBySlug(deviceType).then(function(manifest) {
+  return utils.getManifestByDeviceType(image, deviceType).then(function(manifest) {
     return operations.execute(image, manifest.initialization.operations, options);
   });
 };

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -56,7 +56,8 @@ utils = require('./utils')
 ###
 exports.configure = (image, uuid, options) ->
 	Promise.props
-		manifest: utils.getManifestByDevice(uuid)
+		manifest: resin.models.device.get(uuid).then (device) ->
+			utils.getManifestByDeviceType(image, device.device_type)
 		config: deviceConfig.getByDevice(uuid, options)
 	.then (results) ->
 		configuration = results.manifest.configuration
@@ -99,5 +100,5 @@ exports.configure = (image, uuid, options) ->
 # 		console.log('Configuration finished')
 ###
 exports.initialize = (image, deviceType, options) ->
-	resin.models.device.getManifestBySlug(deviceType).then (manifest) ->
+	utils.getManifestByDeviceType(image, deviceType).then (manifest) ->
 		return operations.execute(image, manifest.initialization.operations, options)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "resin-device-operations": "^1.2.5",
     "resin-image-fs": "^2.1.0",
     "resin-sdk": "^5.2.0",
+    "rindle": "^1.3.0",
     "string-to-stream": "^1.0.1"
   }
 }


### PR DESCRIPTION
This PR extends the way we fetch the device type for the device we're
just about to initialise by trying to fetch it from the first partition
before falling back to the API.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>