### PR TITLE
Move to preconfigured Resin-SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Moved to [resin-sdk-preconfigured](https://github.com/resin-io-modules/resin-sdk-preconfigured)
+
 ## [2.1.0] - 2016-09-14
 
 - Attempt to get `device-type.json` from the image's first partition.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ Documentation
 
 
 * [init](#module_init)
-  * [.configure(image, uuid, options)](#module_init.configure) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
-  * [.initialize(image, deviceType, options)](#module_init.initialize) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
+    * [.configure(image, uuid, options)](#module_init.configure) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
+    * [.initialize(image, deviceType, options)](#module_init.initialize) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
 
 <a name="module_init.configure"></a>
+
 ### init.configure(image, uuid, options) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
 This function injects `config.json` into the device.
 
@@ -66,6 +67,7 @@ init.configure('my/rpi.img', '7cf02a62a3a84440b1bb5579a3d57469148943278630b17e7f
 		console.log('Configuration finished')
 ```
 <a name="module_init.initialize"></a>
+
 ### init.initialize(image, deviceType, options) ⇒ <code>Promise.&lt;EventEmitter&gt;</code>
 **Kind**: static method of <code>[init](#module_init)</code>  
 **Summary**: Initialize an image  
@@ -123,6 +125,12 @@ Before submitting a PR, please make sure that you include tests, and that [coffe
 
 ```sh
 $ gulp lint
+```
+
+To run the tests, you'll need to ensure that `RESIN_E2E_EMAIL` and `RESIN_E2E_PASSWORD` in your environment are set to valid credentials for a test user on [resinstaging.io](https://resinstaging.io). You can then run the tests with:
+
+```sh
+npm test
 ```
 
 License

--- a/build/init.js
+++ b/build/init.js
@@ -22,7 +22,7 @@ var Promise, deviceConfig, operations, resin, utils;
 
 Promise = require('bluebird');
 
-resin = require('resin-sdk');
+resin = require('resin-sdk-preconfigured');
 
 deviceConfig = require('resin-device-config');
 

--- a/build/utils.js
+++ b/build/utils.js
@@ -28,7 +28,7 @@ stringToStream = require('string-to-stream');
 
 imagefs = require('resin-image-fs');
 
-resin = require('resin-sdk');
+resin = require('resin-sdk-preconfigured');
 
 
 /**

--- a/doc/README.hbs
+++ b/doc/README.hbs
@@ -61,6 +61,12 @@ Before submitting a PR, please make sure that you include tests, and that [coffe
 $ gulp lint
 ```
 
+To run the tests, you'll need to ensure that `RESIN_E2E_EMAIL` and `RESIN_E2E_PASSWORD` in your environment are set to valid credentials for a test user on [resinstaging.io](https://resinstaging.io). You can then run the tests with:
+
+```sh
+npm test
+```
+
 License
 -------
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -19,7 +19,7 @@ limitations under the License.
 ###
 
 Promise = require('bluebird')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 deviceConfig = require('resin-device-config')
 operations = require('resin-device-operations')
 utils = require('./utils')

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -20,7 +20,7 @@ _ = require('lodash')
 path = require('path')
 stringToStream = require('string-to-stream')
 imagefs = require('resin-image-fs')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 
 ###*
 # @summary Get device type manifest by a device type name

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "resin-device-config": "^3.0.1",
     "resin-device-operations": "^1.2.5",
     "resin-image-fs": "^2.1.0",
-    "resin-sdk": "^5.2.0",
+    "resin-sdk-preconfigured": "^0.1.0",
     "rindle": "^1.3.0",
     "string-to-stream": "^1.0.1"
   }

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -5,7 +5,7 @@ path = require('path')
 Promise = require('bluebird')
 fs = Promise.promisifyAll(require('fs'))
 wary = require('wary')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 imagefs = require('resin-image-fs')
 init = require('../lib/init')
 
@@ -21,7 +21,7 @@ prepareDevice = (deviceType) ->
 	resin.models.application.has(applicationName).then (hasApplication) ->
 		return if hasApplication
 		resin.models.application.create(applicationName, deviceType)
-	.then(resin.models.device.generateUUID)
+	.then(resin.models.device.generateUniqueKey)
 	.then (uuid) ->
 		resin.models.device.register(applicationName, uuid)
 	.get('uuid')

--- a/tests/e2e.coffee
+++ b/tests/e2e.coffee
@@ -358,7 +358,7 @@ wary.it 'should be able to initialize an intel edison with a script',
 			m.chai.expect(stderr).to.equal('')
 
 resin.auth.login
-	email: process.env.RESIN_E2E_USERNAME
+	email: process.env.RESIN_E2E_EMAIL
 	password: process.env.RESIN_E2E_PASSWORD
 .then ->
 	console.log('Logged in')


### PR DESCRIPTION
Much like https://github.com/resin-io/resin-config-json/pull/4, this PR is failing, because master on the repo is (after rerunning [the build](https://ci.appveyor.com/project/resin-io/resin-device-init)) failing. Note that only appveyor visibly fails, because Travis ignores the error output and just sees zero tests, but both are broken.

Looks like some of our image metadata has changed, but I don't have enough context to know whether the values this is seeing are correct or not.

I have had to update this to the new device registration API to get to these errors, and I've also documented and tweaked the test setup, since it was a little opaque.

